### PR TITLE
fix(dependencies) Freeze npm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,12 +49,12 @@
   },
   "dependencies": {
     "angular2": "2.0.0-beta.15",
-    "bootstrap": "^3.3.6",
-    "core-js": "^2.2.2",
-    "material-design-icons": "^2.2.3",
-    "ng2-bootstrap": "^1.0.7",
+    "bootstrap": "3.3.6",
+    "core-js": "2.2.2",
+    "material-design-icons": "2.2.3",
+    "ng2-bootstrap": "1.0.7",
     "ng2-modal": "0.0.2",
-    "ng2-toastr": "^0.1.6",
+    "ng2-toastr": "0.1.6",
     "rxjs": "5.0.0-beta.2",
     "zone.js": "0.6.10"
   },


### PR DESCRIPTION
I've got some regression with latest ng2-toaster version. Freeze npm dependencies with volatile modules is a better practice.
